### PR TITLE
Added optional User Authentication

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -185,7 +185,7 @@ ntfy_configuration: "{{ ntfy_configuration_yaml | from_yaml | combine(ntfy_confi
 # ntfy_credentials:
 #   - username: user1
 #     password: password1
-#     admin: false
+#     admin: true
 #   - username: user2
 #     password: password2
 #     admin: true

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -177,3 +177,15 @@ ntfy_configuration_extension: "{{ ntfy_configuration_extension_yaml | from_yaml 
 # Holds the final ntfy configuration (a combination of the default and its extension).
 # You most likely don't need to touch this variable. Instead, see `ntfy_configuration_yaml`.
 ntfy_configuration: "{{ ntfy_configuration_yaml | from_yaml | combine(ntfy_configuration_extension, recursive=True) }}"
+
+# List of user credentials for ntfy authentication.
+# If left empty (ntfy_credentials: []), authentication will be disabled, 
+# allowing unrestricted access to all topics.
+# To enable authentication, add users with a username and password:
+# ntfy_credentials:
+#   - username: user1
+#     password: password1
+#   - username: user2
+#     password: password2
+# When credentials are provided, ntfy will enforce authentication.
+ntfy_credentials: []

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -185,7 +185,9 @@ ntfy_configuration: "{{ ntfy_configuration_yaml | from_yaml | combine(ntfy_confi
 # ntfy_credentials:
 #   - username: user1
 #     password: password1
+#     admin: false
 #   - username: user2
 #     password: password2
+#     admin: true
 # When credentials are provided, ntfy will enforce authentication.
 ntfy_credentials: []

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -50,3 +50,4 @@
     src: "{{ role_path }}/templates/systemd/ntfy.service.j2"
     dest: "{{ devture_systemd_docker_base_systemd_path }}/{{ ntfy_identifier }}.service"
     mode: 0644
+

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,7 +7,9 @@
     - when: ntfy_enabled | bool
       ansible.builtin.include_tasks: "{{ role_path }}/tasks/install.yml"
 
-    - when: ntfy_enabled | bool
+    - when: 
+        - ntfy_enabled | bool
+        - ntfy_credentials | length > 0
       ansible.builtin.include_tasks: "{{ role_path }}/tasks/setup_users.yml"
 
   tags:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,6 +6,10 @@
 
     - when: ntfy_enabled | bool
       ansible.builtin.include_tasks: "{{ role_path }}/tasks/install.yml"
+
+    - when: ntfy_enabled | bool
+      ansible.builtin.include_tasks: "{{ role_path }}/tasks/setup_users.yml"
+
   tags:
     - setup-all
     - setup-ntfy

--- a/tasks/setup_users.yml
+++ b/tasks/setup_users.yml
@@ -1,6 +1,6 @@
 ---
 
-- name: Restart ntfy container to create user database
+- name: Restart ntfy service to create user database
   ansible.builtin.systemd:
     name: "{{ ntfy_identifier }}"
     state: restarted

--- a/tasks/setup_users.yml
+++ b/tasks/setup_users.yml
@@ -1,6 +1,6 @@
 ---
 
-- name: Restart ntfy container to create user database
+- name: Restart ntfy service to ensure user database is created
   ansible.builtin.systemd:
     name: "{{ ntfy_identifier }}"
     daemon_reload: true

--- a/tasks/setup_users.yml
+++ b/tasks/setup_users.yml
@@ -1,43 +1,36 @@
-
 ---
-- name: Create ntfy users
+
+- name: Restart ntfy container to create user database
+  ansible.builtin.systemd:
+    name: "{{ ntfy_identifier }}"
+    state: restarted
+  when: ntfy_credentials | length > 0
+
+- name: Allow anonymous write access for push messages
   command: >
-    {{ devture_systemd_docker_base_host_command_sh }} -c '{{ devture_systemd_docker_base_host_command_docker }} run \
-    --rm \
-    --env NTFY_PASSWORD={{ item.password }} \
-    --user={{ ntfy_uid }}:{{ ntfy_gid }} \
-    --mount type=bind,src={{ ntfy_config_dir_path }},dst=/etc/ntfy,ro \
-    --mount type=bind,src={{ ntfy_data_path }},dst=/data \
-    --network none \
-    {{ ntfy_container_image }} \
-    ntfy user add --role={{ item.admin | ternary("admin", "user") }} {{ item.username }}'
+    {{ devture_systemd_docker_base_host_command_sh }} -c '{{ devture_systemd_docker_base_host_command_docker }} run  --rm --env NTFY_PASSWORD={{ item.password }} --user={{ ntfy_uid }}:{{ ntfy_gid }} --mount type=bind,src={{ ntfy_config_dir_path }},dst=/etc/ntfy,ro --mount type=bind,src={{ ntfy_data_path }},dst=/data --network none {{ ntfy_container_image }}  access '*' 'up*' write-only'
   with_items: "{{ ntfy_credentials }}"
   when: ntfy_credentials | length > 0
+  ignore_errors: yes
+
+- name: Create ntfy users
+  command: >
+    {{ devture_systemd_docker_base_host_command_sh }} -c '{{ devture_systemd_docker_base_host_command_docker }} run  --rm --env NTFY_PASSWORD={{ item.password }} --user={{ ntfy_uid }}:{{ ntfy_gid }} --mount type=bind,src={{ ntfy_config_dir_path }},dst=/etc/ntfy,ro --mount type=bind,src={{ ntfy_data_path }},dst=/data --network none {{ ntfy_container_image }} user add {{ item.username }}'
+  with_items: "{{ ntfy_credentials }}"
+  when: ntfy_credentials | length > 0
+  ignore_errors: yes
 
 - name: Write ntfy users passwords
   command: >
-    {{ devture_systemd_docker_base_host_command_sh }} -c '{{ devture_systemd_docker_base_host_command_docker }} run \
-    --rm \
-    --env NTFY_PASSWORD={{ item.password }} \
-    --user={{ ntfy_uid }}:{{ ntfy_gid }} \
-    --mount type=bind,src={{ ntfy_config_dir_path }},dst=/etc/ntfy,ro \
-    --mount type=bind,src={{ ntfy_data_path }},dst=/data \
-    --network none \
-    {{ ntfy_container_image }} \
-    ntfy user change-pass {{ item.username }}'
+    {{ devture_systemd_docker_base_host_command_sh }} -c '{{ devture_systemd_docker_base_host_command_docker }} run  --rm --env NTFY_PASSWORD={{ item.password }} --user={{ ntfy_uid }}:{{ ntfy_gid }} --mount type=bind,src={{ ntfy_config_dir_path }},dst=/etc/ntfy,ro --mount type=bind,src={{ ntfy_data_path }},dst=/data --network none {{ ntfy_container_image }} user change-pass {{ item.username }}'
   with_items: "{{ ntfy_credentials }}"
   when: ntfy_credentials | length > 0
+  ignore_errors: yes
 
 - name: Write ntfy users roles
   command: >
-    {{ devture_systemd_docker_base_host_command_sh }} -c '{{ devture_systemd_docker_base_host_command_docker }} run \
-    --rm \
-    --env NTFY_PASSWORD={{ item.password }} \
-    --user={{ ntfy_uid }}:{{ ntfy_gid }} \
-    --mount type=bind,src={{ ntfy_config_dir_path }},dst=/etc/ntfy,ro \
-    --mount type=bind,src={{ ntfy_data_path }},dst=/data \
-    --network none \
-    {{ ntfy_container_image }} \
-    ntfy user change-role {{ item.username }} {{ item.admin | ternary("admin", "user") }}'
+    {{ devture_systemd_docker_base_host_command_sh }} -c '{{ devture_systemd_docker_base_host_command_docker }} run  --rm --env NTFY_PASSWORD={{ item.password }} --user={{ ntfy_uid }}:{{ ntfy_gid }} --mount type=bind,src={{ ntfy_config_dir_path }},dst=/etc/ntfy,ro --mount type=bind,src={{ ntfy_data_path }},dst=/data --network none {{ ntfy_container_image }} user change-role {{ item.username }} {{ item.admin | ternary("admin", "user") }}'
   with_items: "{{ ntfy_credentials }}"
   when: ntfy_credentials | length > 0
+  ignore_errors: yes
+

--- a/tasks/setup_users.yml
+++ b/tasks/setup_users.yml
@@ -1,36 +1,109 @@
 ---
 
-- name: Restart ntfy service to create user database
+- name: Restart ntfy container to create user database
   ansible.builtin.systemd:
     name: "{{ ntfy_identifier }}"
+    daemon_reload: true
     state: restarted
-  when: ntfy_credentials | length > 0
 
-- name: Allow anonymous write access for push messages
-  command: >
-    {{ devture_systemd_docker_base_host_command_sh }} -c '{{ devture_systemd_docker_base_host_command_docker }} run  --rm --env NTFY_PASSWORD={{ item.password }} --user={{ ntfy_uid }}:{{ ntfy_gid }} --mount type=bind,src={{ ntfy_config_dir_path }},dst=/etc/ntfy,ro --mount type=bind,src={{ ntfy_data_path }},dst=/data --network none {{ ntfy_container_image }}  access '*' 'up*' write-only'
-  with_items: "{{ ntfy_credentials }}"
-  when: ntfy_credentials | length > 0
-  ignore_errors: yes
+- name: Allow anonymous write access for push messages 
+  command: |
+    {{ devture_systemd_docker_base_host_command_sh }} -c '{{ devture_systemd_docker_base_host_command_docker }} run \
+    --rm \
+    --user={{ ntfy_uid }}:{{ ntfy_gid }} \
+    --mount type=bind,src={{ ntfy_config_dir_path }},dst=/etc/ntfy,ro \
+    --mount type=bind,src={{ ntfy_data_path }},dst=/data \
+    --network none \
+    {{ ntfy_container_image }} \
+     access '*' 'up*' write-only' 
+  ignore_errors: true
+
+- name: Get existing ntfy users
+  command: |
+    {{ devture_systemd_docker_base_host_command_sh }} -c '{{ devture_systemd_docker_base_host_command_docker }} run \
+    --rm \
+    --user={{ ntfy_uid }}:{{ ntfy_gid }} \
+    --mount type=bind,src={{ ntfy_config_dir_path }},dst=/etc/ntfy,ro \
+    --mount type=bind,src={{ ntfy_data_path }},dst=/data \
+    --network none \
+    {{ ntfy_container_image }} \
+    user list'
+  register: ntfy_users_output
+  changed_when: false
+  failed_when: false
+
+- name: Extract existing users
+  set_fact:
+    existing_users: "{{ (ntfy_users_output.stdout + '\n' + ntfy_users_output.stderr) | regex_findall('user ([^ ]+)') }}"
+
+- name: Extract allowed users from credentials
+  set_fact:
+    allowed_users: "{{ ntfy_credentials | map(attribute='username') | list }}"
+
+- name: Identify users to add
+  set_fact:
+    users_to_add: "{{ allowed_users | difference(existing_users) }}"
 
 - name: Create ntfy users
-  command: >
-    {{ devture_systemd_docker_base_host_command_sh }} -c '{{ devture_systemd_docker_base_host_command_docker }} run  --rm --env NTFY_PASSWORD={{ item.password }} --user={{ ntfy_uid }}:{{ ntfy_gid }} --mount type=bind,src={{ ntfy_config_dir_path }},dst=/etc/ntfy,ro --mount type=bind,src={{ ntfy_data_path }},dst=/data --network none {{ ntfy_container_image }} user add {{ item.username }}'
-  with_items: "{{ ntfy_credentials }}"
-  when: ntfy_credentials | length > 0
-  ignore_errors: yes
+  command: |
+    {{ devture_systemd_docker_base_host_command_sh }} -c '{{ devture_systemd_docker_base_host_command_docker }} run \
+    --rm \
+    --user={{ ntfy_uid }}:{{ ntfy_gid }} \
+    --mount type=bind,src={{ ntfy_config_dir_path }},dst=/etc/ntfy,ro \
+    --mount type=bind,src={{ ntfy_data_path }},dst=/data \
+    --network none \
+    --env NTFY_PASSWORD={{ item.password }} \
+    {{ ntfy_container_image }} \
+    user add --role={{ item.admin | ternary("admin", "user") }} {{ item.username }}'
+  loop: "{{ ntfy_credentials }}"
+  when: item.username in users_to_add
+  ignore_errors: true
 
 - name: Write ntfy users passwords
-  command: >
-    {{ devture_systemd_docker_base_host_command_sh }} -c '{{ devture_systemd_docker_base_host_command_docker }} run  --rm --env NTFY_PASSWORD={{ item.password }} --user={{ ntfy_uid }}:{{ ntfy_gid }} --mount type=bind,src={{ ntfy_config_dir_path }},dst=/etc/ntfy,ro --mount type=bind,src={{ ntfy_data_path }},dst=/data --network none {{ ntfy_container_image }} user change-pass {{ item.username }}'
-  with_items: "{{ ntfy_credentials }}"
-  when: ntfy_credentials | length > 0
-  ignore_errors: yes
+  command: |
+    {{ devture_systemd_docker_base_host_command_sh }} -c '{{ devture_systemd_docker_base_host_command_docker }} run \
+    --rm \
+    --user={{ ntfy_uid }}:{{ ntfy_gid }} \
+    --mount type=bind,src={{ ntfy_config_dir_path }},dst=/etc/ntfy,ro \
+    --mount type=bind,src={{ ntfy_data_path }},dst=/data \
+    --network none \
+    --env NTFY_PASSWORD={{ item.password }} \
+    {{ ntfy_container_image }} \
+    user change-pass {{ item.username }}'
+  loop: "{{ ntfy_credentials }}"
+  when: item.username in existing_users
+  ignore_errors: true
 
 - name: Write ntfy users roles
-  command: >
-    {{ devture_systemd_docker_base_host_command_sh }} -c '{{ devture_systemd_docker_base_host_command_docker }} run  --rm --env NTFY_PASSWORD={{ item.password }} --user={{ ntfy_uid }}:{{ ntfy_gid }} --mount type=bind,src={{ ntfy_config_dir_path }},dst=/etc/ntfy,ro --mount type=bind,src={{ ntfy_data_path }},dst=/data --network none {{ ntfy_container_image }} user change-role {{ item.username }} {{ item.admin | ternary("admin", "user") }}'
+  command: |
+    {{ devture_systemd_docker_base_host_command_sh }} -c '{{ devture_systemd_docker_base_host_command_docker }} run \
+    --rm \
+    --user={{ ntfy_uid }}:{{ ntfy_gid }} \
+    --mount type=bind,src={{ ntfy_config_dir_path }},dst=/etc/ntfy,ro \
+    --mount type=bind,src={{ ntfy_data_path }},dst=/data \
+    --network none \
+    {{ ntfy_container_image }} \
+    user change-role {{ item.username }} {{ item.admin | ternary("admin", "user") }}'
   with_items: "{{ ntfy_credentials }}"
-  when: ntfy_credentials | length > 0
-  ignore_errors: yes
+  loop: "{{ ntfy_credentials }}"
+  when: item.username in existing_users
+  ignore_errors: true
+
+- name: Identify users to delete
+  set_fact:
+    users_to_delete: "{{ existing_users | difference(allowed_users + ['*']) }}"
+
+- name: Delete unwanted users
+  command: |
+    {{ devture_systemd_docker_base_host_command_sh }} -c '{{ devture_systemd_docker_base_host_command_docker }} run \
+    --rm \
+    --user={{ ntfy_uid }}:{{ ntfy_gid }} \
+    --mount type=bind,src={{ ntfy_config_dir_path }},dst=/etc/ntfy,ro \
+    --mount type=bind,src={{ ntfy_data_path }},dst=/data \
+    --network none \
+    {{ ntfy_container_image }} \
+    user del {{ item }}'
+  loop: "{{ users_to_delete }}"
+  when: users_to_delete | length > 0
+  ignore_errors: true
 

--- a/tasks/setup_users.yml
+++ b/tasks/setup_users.yml
@@ -1,0 +1,43 @@
+
+---
+- name: Create ntfy users
+  command: >
+    {{ devture_systemd_docker_base_host_command_sh }} -c '{{ devture_systemd_docker_base_host_command_docker }} run \
+    --rm \
+    --env NTFY_PASSWORD={{ item.password }} \
+    --user={{ ntfy_uid }}:{{ ntfy_gid }} \
+    --mount type=bind,src={{ ntfy_config_dir_path }},dst=/etc/ntfy,ro \
+    --mount type=bind,src={{ ntfy_data_path }},dst=/data \
+    --network none \
+    {{ ntfy_container_image }} \
+    ntfy user add --role={{ item.admin | ternary("admin", "user") }} {{ item.username }}'
+  with_items: "{{ ntfy_credentials }}"
+  when: ntfy_credentials | length > 0
+
+- name: Write ntfy users passwords
+  command: >
+    {{ devture_systemd_docker_base_host_command_sh }} -c '{{ devture_systemd_docker_base_host_command_docker }} run \
+    --rm \
+    --env NTFY_PASSWORD={{ item.password }} \
+    --user={{ ntfy_uid }}:{{ ntfy_gid }} \
+    --mount type=bind,src={{ ntfy_config_dir_path }},dst=/etc/ntfy,ro \
+    --mount type=bind,src={{ ntfy_data_path }},dst=/data \
+    --network none \
+    {{ ntfy_container_image }} \
+    ntfy user change-pass {{ item.username }}'
+  with_items: "{{ ntfy_credentials }}"
+  when: ntfy_credentials | length > 0
+
+- name: Write ntfy users roles
+  command: >
+    {{ devture_systemd_docker_base_host_command_sh }} -c '{{ devture_systemd_docker_base_host_command_docker }} run \
+    --rm \
+    --env NTFY_PASSWORD={{ item.password }} \
+    --user={{ ntfy_uid }}:{{ ntfy_gid }} \
+    --mount type=bind,src={{ ntfy_config_dir_path }},dst=/etc/ntfy,ro \
+    --mount type=bind,src={{ ntfy_data_path }},dst=/data \
+    --network none \
+    {{ ntfy_container_image }} \
+    ntfy user change-role {{ item.username }} {{ item.admin | ternary("admin", "user") }}'
+  with_items: "{{ ntfy_credentials }}"
+  when: ntfy_credentials | length > 0

--- a/templates/ntfy/server.yml.j2
+++ b/templates/ntfy/server.yml.j2
@@ -11,3 +11,9 @@ visitor-request-limit-burst: {{ ntfy_visitor_request_limit_burst | to_json }}
 visitor-request-limit-replenish: {{ ntfy_visitor_request_limit_replenish | to_json }}
 
 web-root: {{ ntfy_web_root | to_json }}
+
+
+{% if ntfy_credentials | length > 0 %}
+auth-file: /data/auth.db
+auth-default-access: deny-all
+{% endif %}


### PR DESCRIPTION
The CLI commands are written in a single line because the / escape didn’t work as expected.

Additionally, after adding an auth database to the config, the container requires a restart. I've implemented this restart via systemd. If there's a more elegant solution, I’m happy to update it accordingly.