### PR TITLE
Update docs/configuring-ntfy.md

### DIFF
--- a/docs/configuring-ntfy.md
+++ b/docs/configuring-ntfy.md
@@ -26,7 +26,7 @@ It is also compatible with [UnifiedPush](https://unifiedpush.org), the standard 
 
 See the project's [documentation](https://docs.ntfy.sh/) to learn what ntfy does and why it might be useful to you.
 
-**Note**: In contrast to push notifications using Google's FCM or Apple's APNs, the use of UnifiedPush allows each end-user to choose the push notification server that they prefer. As a consequence, deploying this ntfy server does not by itself ensure any particular user or device or client app will use it.
+**Note**: unlike push notifications using Google's FCM or Apple's APNs, each end-user can choose the UnifiedPush-enabled push notification server that one prefer. This means that deploying a ntfy server does not ensure any particular user, device or application will use it.
 
 ## Adjusting the playbook configuration
 

--- a/docs/configuring-ntfy.md
+++ b/docs/configuring-ntfy.md
@@ -93,6 +93,8 @@ To enable it, add the following configuration to your `vars.yml` file:
 ntfy_web_root: "app"
 ```
 
+See [this section](https://docs.ntfy.sh/subscribe/web/) on the official documentation for details about how to use the web app.
+
 ### Enable E-mail notification (optional)
 
 ntfy can forward notification messages as email via a SMTP server for outgoing messages. If configured, you can set the `X-Email` header to send messages as email (e.g. `curl -d "This is a test notification to my email address" -H "X-Email: alice@example.com" example.com/example_topic`).

--- a/docs/configuring-ntfy.md
+++ b/docs/configuring-ntfy.md
@@ -24,7 +24,7 @@ ntfy lets you send push notifications to your phone or desktop via scripts from 
 
 See the project's [documentation](https://docs.ntfy.sh/) to learn what ntfy does and why it might be useful to you.
 
-**Note**: you need to install [the `ntfy` app](https://docs.ntfy.sh/subscribe/phone/) on the device in order to receive push notifications from the ntfy server. Notifications can also be sent/received on the ntfy's web app. Refer [this section](#usage) for details about how to use the apps.
+**Note**: you need to install [the ntfy Android/iOS app](https://docs.ntfy.sh/subscribe/phone/) on the device in order to receive push notifications from the ntfy server. Notifications can also be sent/received on the ntfy's web app. Refer [this section](#usage) for details about how to use the apps.
 
 ### UnifiedPush support
 
@@ -32,11 +32,11 @@ ntfy implements [UnifiedPush](https://unifiedpush.org), the standard which makes
 
 Working as a **Push Server**, a ntfy server can forward messages to a **Distributor** running on Android and other devices (see [here](https://unifiedpush.org/users/distributors/#definitions) for the definition of the Push Server and the Distributor).
 
-This role installs and manages a self-hosted ntfy server as the Push Server, which the Distributor (such as `ntfy` app) on your device listens to.
+This role installs and manages a self-hosted ntfy server as the Push Server, which the Distributor (such as ntfy Android app) on your device listens to.
 
 Your UnifiedPush-compatible applications (such as [Tusky](https://tusky.app/) and [DAVx⁵](https://www.davx5.com/)) listen to the Distributor, and push notitications are "distributed" from it. This means that the UnifiedPush-compatible applications cannot receive push notifications from the Push Server without the Distributor.
 
-As `ntfy` app functions as the Distributor too, you do not have to install something else on your device.
+As ntfy Android app functions as the Distributor too, you do not have to install something else on your device.
 
 💡 **Notes**:
 - Refer [this official documentation of UnifiedPush](https://unifiedpush.org/users/troubleshooting/#understand-unifiedpush) for a simple explanation about relationship among UnifiedPush-compatible application, Distributor, Push Server, and the application's server.
@@ -196,11 +196,11 @@ If you use the MDAD / MASH playbook, the shortcut commands with the [`just` prog
 
 ## Usage
 
-To receive push notifications from your ntfy server, you need to **install [the `ntfy` app](https://docs.ntfy.sh/subscribe/phone/)** and then **subscribe to a topic** where messages will be published. You can also send/receive notifications on the ntfy's web app at `example.com`.
+To receive push notifications from your ntfy server, you need to **install [the ntfy Android/iOS app](https://docs.ntfy.sh/subscribe/phone/)** and then **subscribe to a topic** where messages will be published. You can also send/receive notifications on the ntfy's web app at `example.com`.
 
-### Install the `ntfy` app
+### Install the ntfy Android/iOS app
 
-To set up the app, you can follow the steps below:
+To set up the Android app, you can follow the steps below:
 
 1. Install the [ntfy Android app](https://docs.ntfy.sh/subscribe/phone/) from F-droid or Google Play.
 2. In its Settings -> `General: Default server`, enter the ntfy server URL, such as `https://ntfy.example.com`.
@@ -234,7 +234,7 @@ ntfy is built as [progressive web app (PWA)](https://docs.ntfy.sh/subscribe/pwa/
 
 ### UnifiedPush-compatible application
 
-To receive push notification on a UnifiedPush-compatible application, it must be able to communicate with the `ntfy` app which works as the Distributor on the same device.
+To receive push notification on a UnifiedPush-compatible application, it must be able to communicate with the ntfy Android app which works as the Distributor on the same device.
 
 Consult to documentation of applications for instruction about how to enable UnifiedPush support. Note that some applications quietly detect and use the Distributor, so you do not always have to configure the applications.
 

--- a/docs/configuring-ntfy.md
+++ b/docs/configuring-ntfy.md
@@ -43,6 +43,12 @@ As ntfy Android app functions as the Distributor too, you do not have to install
 - Unlike push notifications using Google's FCM or Apple's APNs, each end-user can choose the Push Server which one prefer. This means that deploying a ntfy server cannot enforce a UnifiedPush-compatible application (and its users) to use the exact server.
 - [UnifiedPush does not work on iOS](https://unifiedpush.org/users/faq/#will-unifiedpush-ever-work-on-ios).
 
+### iOS instant notification
+
+Because iOS heavily restricts background processing, it is impossible to implement instant push notifications without a central server.
+
+To implement instant notification through the self-hosted ntfy server, see [this official documentation](https://docs.ntfy.sh/config/#ios-instant-notifications) for instructions.
+
 ## Adjusting the playbook configuration
 
 To enable a self-hosted ntfy server with this role, add the following configuration to your `vars.yml` file.

--- a/docs/configuring-ntfy.md
+++ b/docs/configuring-ntfy.md
@@ -20,7 +20,9 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 
 This is an [Ansible](https://www.ansible.com/) role which installs [ntfy](https://ntfy.sh/) to run as a [Docker](https://www.docker.com/) container wrapped in a systemd service.
 
-Using the [UnifiedPush](https://unifiedpush.org) standard, ntfy enables self-hosted (Google-free) push notifications from servers to UnifiedPush-compatible apps running on Android and other devices.
+ntfy lets you send push notifications to your phone or desktop via scripts from any computer, using simple HTTP PUT or POST requests.
+
+It is also compatible with [UnifiedPush](https://unifiedpush.org), the standard which enables receiving push notifications without using Google's Firebase Cloud Messaging (FCM) service. Working as a **UnifiedPush distributor**, ntfy can forward messages to UnifiedPush-compatible apps running on Android and other devices.
 
 See the project's [documentation](https://docs.ntfy.sh/) to learn what ntfy does and why it might be useful to you.
 


### PR DESCRIPTION
ntfy implements UnifiedPush, but it is at its core an application which can send/receive notifications with HTTP PUT/POST requests.

The main intent of this PR is to clarify that ntfy supports UnifiedPush but it has its own functions which are not related to UnifiedPush, and describe how those ntfy-specific functions can be configured, making clear at the same time what this role installs (ie. a self-hosted ntfy server; which can act as [Push Server](https://unifiedpush.org/users/distributors/#definitions) in terms of UnifiedPush).

Initially the file has lacked descriptions about ntfy's own functions, mainly because the documentation was initially copied from the MDAD project.
