### PR TITLE
Update setup_users.yml: fix quotation

### DIFF
--- a/tasks/setup_users.yml
+++ b/tasks/setup_users.yml
@@ -19,8 +19,7 @@
     --mount type=bind,src={{ ntfy_data_path }},dst=/data \
     --network none \
     {{ ntfy_container_image }} \
-    access '*' 'up*' write-only'
-  ignore_errors: true
+    access "*" "up*" write-only'
 
 - name: Get existing ntfy users
   command: |


### PR DESCRIPTION
Considering an example at https://docs.ntfy.sh/config/#access-control-list-acl (ntfy access everyone "up*" write), wildcard characters do not have be wrapped by single quotation marks. I've also confirmed by running "ntfy access" on the container that "user *" was successfully registered.

cf. https://github.com/spantaleev/matrix-docker-ansible-deploy/issues/4183